### PR TITLE
Fixed clang warning

### DIFF
--- a/argparse.hpp
+++ b/argparse.hpp
@@ -42,7 +42,7 @@ typedef std::map<std::string, size_t> IndexMap;
 class ArgumentParser {
 private:
     class Any;
-    class Argument;
+    struct Argument;
     class PlaceHolder;
     class Holder;
     typedef std::string String;


### PR DESCRIPTION
Argument seems to be a struct rather than a class.